### PR TITLE
Support scroll multiple items

### DIFF
--- a/UPCarouselFlowLayout.podspec
+++ b/UPCarouselFlowLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "UPCarouselFlowLayout"
-  s.version          = "1.1.1"
+  s.version          = "1.1.2"
   s.summary          = "A fancy carousel flow layout for UICollectionView."
   s.description      = "UPCarouselFlowLayout is a fancy carousel flow layout for UICollectionView. It comes with a paginated effect and it shrinks and makes transparent the side items."
 
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   # s.screenshots     = "https://github.com/ink-spot/UPCarouselFlowLayout/raw/master/images/demo.gif"
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'Paul Ulric' => 'ink.and.spot@gmail.com' }
-  s.source           = { :git => 'https://github.com/ink-spot/UPCarouselFlowLayout.git', :tag => s.version.to_s }
+  s.source           = { :git => 'https://github.com/dangthaison91/UPCarouselFlowLayout', :tag => s.version.to_s }
 
   s.ios.deployment_target = '8.1'
 


### PR DESCRIPTION
Currently, layout only support swipe item one by one, not support quick swipe / flick like this:
https://d13yacurqjgara.cloudfront.net/users/365019/screenshots/3132598/discover_alt.gif

https://dribbble.com/shots/3132598-Carousel

This pull request will add support for scroll multiple items, flick / quick swipe. You can also change Scroll Deceleration Rate.