### PR TITLE
Update podspec source_files to only include .h and .swift files (fixes error in the new build system)

### DIFF
--- a/UPCarouselFlowLayout.podspec
+++ b/UPCarouselFlowLayout.podspec
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '8.1'
 
-  s.source_files = 'UPCarouselFlowLayout/**/*'
+  s.source_files = 'UPCarouselFlowLayout/**/*.{h,swift}'
 
 end


### PR DESCRIPTION
The new build system throws an error if there are plist files in the target's sources. By changing the source_files regex we ensure the Info.plist is not added when we pod install.