### PR TITLE
RTL Support

### DIFF
--- a/UPCarouselFlowLayout/UPCarouselFlowLayout.swift
+++ b/UPCarouselFlowLayout/UPCarouselFlowLayout.swift
@@ -8,12 +8,10 @@
 
 import UIKit
 
-
 public enum UPCarouselFlowLayoutSpacingMode {
     case fixed(spacing: CGFloat)
     case overlap(visibleOffset: CGFloat)
 }
-
 
 open class UPCarouselFlowLayout: UICollectionViewFlowLayout {
     
@@ -31,7 +29,6 @@ open class UPCarouselFlowLayout: UICollectionViewFlowLayout {
     open var spacingMode = UPCarouselFlowLayoutSpacingMode.fixed(spacing: 40)
     
     fileprivate var state = LayoutState(size: CGSize.zero, direction: .horizontal)
-    
     
     override open func prepare() {
         super.prepare()
@@ -134,5 +131,8 @@ open class UPCarouselFlowLayout: UICollectionViewFlowLayout {
         
         return targetContentOffset
     }
+    
+    override open var flipsHorizontallyInOppositeLayoutDirection: Bool {
+        return true
+    }
 }
-

--- a/UPCarouselFlowLayoutDemo.xcodeproj/project.pbxproj
+++ b/UPCarouselFlowLayoutDemo.xcodeproj/project.pbxproj
@@ -59,7 +59,6 @@
 		01D387961D229BFC00CE4E1F /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		01D387A21D229E4A00CE4E1F /* UPCarouselFlowLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UPCarouselFlowLayout.swift; sourceTree = "<group>"; };
 		841C94F01DDEE4E300B997F5 /* UPCarouselFlowLayout.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UPCarouselFlowLayout.h; sourceTree = "<group>"; };
-		841C94F11DDEE4E300B997F5 /* UPCarouselFlowLayout.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UPCarouselFlowLayout.m; sourceTree = "<group>"; };
 		841C94FD1DDEE57F00B997F5 /* UPCarouselFlowLayout.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = UPCarouselFlowLayout.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		841C94FF1DDEE57F00B997F5 /* UPCarouselFlowLayout.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UPCarouselFlowLayout.h; sourceTree = "<group>"; };
 		841C95001DDEE57F00B997F5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -106,7 +105,6 @@
 		01D3878A1D229BFC00CE4E1F /* UPCarouselFlowLayoutDemo */ = {
 			isa = PBXGroup;
 			children = (
-				01D387A11D229E4A00CE4E1F /* UPCarouselFlowLayout */,
 				01D3878B1D229BFC00CE4E1F /* AppDelegate.swift */,
 				01D387931D229BFC00CE4E1F /* GradientView.swift */,
 				01D387961D229BFC00CE4E1F /* ViewController.swift */,
@@ -120,19 +118,11 @@
 			path = UPCarouselFlowLayoutDemo;
 			sourceTree = "<group>";
 		};
-		01D387A11D229E4A00CE4E1F /* UPCarouselFlowLayout */ = {
-			isa = PBXGroup;
-			children = (
-				01D387A21D229E4A00CE4E1F /* UPCarouselFlowLayout.swift */,
-			);
-			path = UPCarouselFlowLayout;
-			sourceTree = SOURCE_ROOT;
-		};
 		841C94EF1DDEE4E300B997F5 /* UPCarouselFlowLayout */ = {
 			isa = PBXGroup;
 			children = (
 				841C94F01DDEE4E300B997F5 /* UPCarouselFlowLayout.h */,
-				841C94F11DDEE4E300B997F5 /* UPCarouselFlowLayout.m */,
+				01D387A21D229E4A00CE4E1F /* UPCarouselFlowLayout.swift */,
 			);
 			path = UPCarouselFlowLayout;
 			sourceTree = "<group>";


### PR DESCRIPTION
Use [`flipsHorizontallyInOppositeLayoutDirection`](https://developer.apple.com/documentation/uikit/uicollectionviewlayout/2891099-flipshorizontallyinoppositelayou) to support Right-To-Left languages.

> A Boolean value indicating whether the horizontal coordinate system is automatically flipped at appropriate times.

| LTR  | RTL  |
|---|---|
| <img src="https://user-images.githubusercontent.com/5849587/48359395-c89bc480-e694-11e8-8f67-b74dbe4e9a8a.gif" width="300">  | <img src="https://user-images.githubusercontent.com/5849587/48359393-c89bc480-e694-11e8-911d-714a40cdca2b.gif" width="300">  |

Fixes #29 